### PR TITLE
Swift-Tools lowering. Sleep.delay if-else.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/DelayableIndicator/DelayableIndicator.swift
+++ b/Sources/DelayableIndicator/DelayableIndicator.swift
@@ -33,7 +33,11 @@ public struct DelayableIndicator<Content: View>: View {
             
             if newValue {
                 pendingTask = Task {
-                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    if #available(iOS 16.0, *) {
+                        try? await Task.sleep(for: .seconds(delay))
+                    } else {
+                        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    }
                     guard !Task.isCancelled else { return }
                     withAnimation {
                         isPresented = true


### PR DESCRIPTION
Hi,

Wanted to try the indicator but stuck on Swift 6 limitation. Also added a convenient Sleep for clear seconds delay.

Thanks in advance!